### PR TITLE
feat: (tabs) 구조 생성 및 기본 네비게이션 구현

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,0 +1,12 @@
+import { Tabs } from 'expo-router';
+
+export default function TabsLayout() {
+  return (
+    <Tabs>
+      <Tabs.Screen name="index" options={{ title: '홈' }} />
+      <Tabs.Screen name="congestion" options={{ title: '혼잡도' }} />
+      <Tabs.Screen name="information" options={{ title: '편의시설' }} />
+      <Tabs.Screen name="mypage" options={{ title: '마이페이지' }} />
+    </Tabs>
+  );
+}

--- a/app/(tabs)/congestion.tsx
+++ b/app/(tabs)/congestion.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+
+export default function CongestionScreen() {
+  return (
+    <View>
+      <Text>혼잡도 정보</Text>
+    </View>
+  );
+}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View>
+      <Text>홈 화면</Text>
+    </View>
+  );
+}

--- a/app/(tabs)/information.tsx
+++ b/app/(tabs)/information.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+
+export default function InformationScreen() {
+  return (
+    <View>
+      <Text>편의시설 정보</Text>
+    </View>
+  );
+}

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+
+export default function MyPageScreen() {
+  return (
+    <View>
+      <Text>마이페이지</Text>
+    </View>
+  );
+}

--- a/app/onboarding/step3.tsx
+++ b/app/onboarding/step3.tsx
@@ -28,7 +28,8 @@ export default function OnboardingStep3() {
           }
         }
 
-        router.replace('/');
+        router.replace('/(tabs)');
+
       };
 
       fetchTokens();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@react-native-async-storage/async-storage": "2.1.2",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
@@ -24,6 +25,7 @@
     "expo-image": "~2.1.7",
     "expo-linking": "~7.1.5",
     "expo-router": "~5.0.6",
+    "expo-secure-store": "~14.2.3",
     "expo-splash-screen": "~0.30.8",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.4",
@@ -38,9 +40,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5",
-    "expo-secure-store": "~14.2.3",
-    "@react-native-async-storage/async-storage": "2.1.2"
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## 작업 내용
- `(tabs)` 폴더 구조 생성 및 expo-router 기반의 하단 탭 네비게이션 설정
- 홈, 혼잡도, 편의시설, 마이페이지 총 4개 탭 구성
- 각 탭에 해당하는 기본 화면 컴포넌트 작성 (`index.tsx`, `congestion.tsx`, `information.tsx`, `mypage.tsx`)
- 로그인 후 메인 탭 화면으로 진입할 수 있도록 라우팅 구조 반영 (`router.replace('/(tabs)')`)

## 테스트 방법 
- `npx expo start`로 앱 실행
- 온보딩 후 로그인 시 → `(tabs)` 구조로 진입되는지 확인
- 각 탭 눌렀을 때 해당 화면으로 정상 진입되는지 확인

## 추후 작업 예정 
- `tabBarIcon` 추가 및 아이콘 스타일링
- 각 화면 상세 구현 및 API 연동