### PR TITLE
refactor: 분리된 초기화 구조 적용 및 setTimeout 제거

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,22 +30,17 @@ function AnimatedAppLoader({ children, image }: { children: React.ReactNode; ima
     prepare();
   }, [image]);
 
-  // TODO : 로그인, 로그아웃 컨텍스트 API 로직 넣기?
-
   if (!isSplashReady) {
     return null;
   }
 
-  // TODO : AuthContext로 감싸기
   return <AnimatedSplashScreen image={image}>{children}</AnimatedSplashScreen>;
 }
 
 function AnimatedSplashScreen({ children, image }: { children: React.ReactNode; image: number }) {
   const [isAppReady, setAppReady] = useState(false);
-  // ㄴ App이 준비되고, SplashAnimation이 끝나면 보여줌
   const [isSplashAnimationComplete, setSplashAnimationComplete] = useState(false);
   const animation = useRef(new Animated.Value(1)).current;
-  // const {updateUser} = useContext(AuthContext);
 
   useEffect(() => {
     if (isAppReady) {
@@ -60,10 +55,7 @@ function AnimatedSplashScreen({ children, image }: { children: React.ReactNode; 
   const onImageLoaded = async () => {
     try {
       // 데이터 준비
-      await Promise.all([
-        // AsyncStorage.getItem('user').then((user)=>{updateUser?.(user?JSON.parse(user):null)}),
-        // TODO: validating access token
-      ]);
+      await Promise.all([]);
       await SplashScreen.hideAsync();
     } catch (error) {
       console.error(error);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -10,15 +10,11 @@ export default function Index() {
   useEffect(() => {
     if (!isAuthReady) return;
 
-    const timeout = setTimeout(() => {
-      if (user) {
-        router.replace('/(tabs)');
-      } else {
-        router.replace('/onboarding');
-      }
-    }, 300);
-
-    return () => clearTimeout(timeout);
+    if (user) {
+      router.replace('/(tabs)');
+    } else {
+      router.replace('/onboarding');
+    }
   }, [isAuthReady, user]);
 
   if (loading) {

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -10,6 +10,7 @@ export const AuthContext = createContext<AuthContextType>({
   user: null,
   login: async () => {},
   logout: () => {},
+  loadUser: async () => {},
   loading: true,
   isAuthReady: false,
 });
@@ -81,7 +82,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, loading, isAuthReady }}>
+    <AuthContext.Provider value={{ user, login, logout, loadUser, loading, isAuthReady }}>
       {children}
     </AuthContext.Provider>
   );

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -16,6 +16,7 @@ export type AuthContextType = {
   user: FullUser | null;
   login: (token: string) => Promise<void>;
   logout: () => void;
+  loadUser: () => Promise<void>;
   loading: boolean;
   isAuthReady: boolean;
 };


### PR DESCRIPTION
## 📌 PR 요약

앱 초기 진입 시의 **Splash 화면 처리 및 사용자 인증 흐름 개선**을 위한 구조 리팩토링입니다.  
불필요한 `setTimeout`을 제거하고, 명확한 상태 흐름에 따라 초기화-라우팅 과정을 정리했습니다.

---

## ✨ 주요 변경 사항

- `index.tsx`에서 `setTimeout` 제거
- `useAuth()`의 `isAuthReady` 상태에 따라 라우팅 분기 처리
- `AnimatedSplashScreen` 내부에서 `loadUser()` 호출을 시도했으나,
  `AuthProvider`와의 순환 의존 문제가 발생
- 결과적으로 **`AppLoader`는 Splash/초기 준비만 담당**,  
  **`AuthProvider`는 인증 및 사용자 정보 로딩만 담당**하는 구조로 분리

---

## 🧩 구조 정리

| 컴포넌트            | 역할                                                   |
|---------------------|--------------------------------------------------------|
| `AnimatedAppLoader` | Splash 유지 + 초기 준비 완료 타이밍 전달              |
| `AuthProvider`      | 사용자 정보 로딩, 상태 관리 (`user`, `isAuthReady`, `loading`) |
| `index.tsx`         | 상태 기반 라우팅 제어 (`/(tabs)` 또는 `/onboarding`)     |

---

## ✅ 기대 효과

- 구조 순환 문제 해결 (`useInsertionEffect must not schedule updates`)
- 상태 흐름 명확화 및 유지보수성 향상
- 추후 앱 초기화 항목 추가 (테마, 로케일 등) 시에도 확장 용이

---

## 📎 관련 이슈 또는 노트

- React 18에서 `useInsertionEffect` 관련 경고 방지
- 인증 상태 초기화 시점 제어를 통해 UX 최적화
