### PR TITLE
fix: 리프레시 토큰 재요청 로직 수정

### DIFF
--- a/apis/axios.ts
+++ b/apis/axios.ts
@@ -39,40 +39,40 @@ axiosInstance.interceptors.response.use(
       if (originalRequest.url === '/api/auth/reissue') {
         SecureStore.deleteItemAsync('accessToken');
         SecureStore.deleteItemAsync('refreshToken');
+
+        return Promise.reject(error);
       }
 
-      return Promise.reject(error);
+      originalRequest._retry = true;
+
+      if (!refreshPromise) {
+        refreshPromise = (async () => {
+          const refreshToken = await SecureStore.getItemAsync('refreshToken');
+
+          const { data } = await axiosInstance.post('/api/auth/reissue', {
+            refreshToken,
+          });
+          await SecureStore.setItemAsync('accessToken', data.result.accessToken);
+          await SecureStore.setItemAsync('refreshToken', data.result.refreshToken);
+
+          return data.result.accessToken;
+        })()
+          .catch(() => {
+            SecureStore.deleteItemAsync('accessToken');
+            SecureStore.deleteItemAsync('refreshToken');
+          })
+          .finally(() => {
+            refreshPromise = null;
+          });
+      }
+
+      return refreshPromise.then(newAccessToken => {
+        originalRequest.headers = {
+          ...originalRequest.headers,
+          Authorization: `Bearer ${newAccessToken}`,
+        };
+        return axiosInstance.request(originalRequest);
+      });
     }
-
-    originalRequest._retry = true;
-
-    if (!refreshPromise) {
-      refreshPromise = (async () => {
-        const refreshToken = await SecureStore.getItemAsync('refreshToken');
-
-        const { data } = await axiosInstance.post('/api/auth/reissue', {
-          refreshToken,
-        });
-        await SecureStore.setItemAsync('accessToken', data.result.accessToken);
-        await SecureStore.setItemAsync('refreshToken', data.result.refreshToken);
-
-        return data.result.accessToken;
-      })()
-        .catch(() => {
-          SecureStore.deleteItemAsync('accessToken');
-          SecureStore.deleteItemAsync('refreshToken');
-        })
-        .finally(() => {
-          refreshPromise = null;
-        });
-    }
-
-    return refreshPromise.then(newAccessToken => {
-      originalRequest.headers = {
-        ...originalRequest.headers,
-        Authorization: `Bearer ${newAccessToken}`,
-      };
-      return axiosInstance.request(originalRequest);
-    });
   },
 );


### PR DESCRIPTION
## 개요 ✏️
JWT 만료 시 리프레시 토큰으로 새로운 토큰을 요청하는 로직에서,
스코프 문제로 인해 재요청이 되지 않던 오류를 수정했습니다.

## 변경 내용 🔧
- Axios response interceptor의 조건문 분기 수정
- refreshPromise 로직이 항상 실행되도록 조건 정리
- 콘솔 디버깅 코드 추가로 동작 확인

## 확인 방법 ✅
- accessToken 만료 시 자동으로 refresh 요청되는지 확인
- refresh 실패 시 accessToken/refreshToken 삭제 여부 확인
