### PR TITLE
refactor: 공지 읽음 상태 저장 구조를 Map 기반으로 변경

### DIFF
--- a/app/(tabs)/alert.tsx
+++ b/app/(tabs)/alert.tsx
@@ -1,6 +1,7 @@
 import { myFavorite } from '@/apis/favorite';
 import LargeButton from '@/components/Button/LargeButton';
 import WeatherHeader from '@/components/Header/WeatherHeader';
+import { useNoticeContext } from '@/context/NoticeContext';
 import { theme } from '@/styles/theme';
 import { StationInfo } from '@/types/common';
 import { hp, px, wp } from '@/utils/scale';
@@ -389,9 +390,11 @@ export default function AlarmScreen() {
     setCurrentBottomSheetView('mainAlarmSettings');
   }, []);
 
+  const { isNewUnreadExists } = useNoticeContext();
+
   return (
     <View style={{ flex: 1 }}>
-      <WeatherHeader />
+      <WeatherHeader showAlarmDot={isNewUnreadExists} />
       <View style={styles.mainContainer}>
         <View style={styles.textContainer}>
           <Text style={styles.text}>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -100,10 +100,16 @@ export default function HomeScreen() {
         </Text>
 
         <DirectAccessCard
-          title={`신사역의 엘리베이터 위치가\n알고 싶다면?`}
+          title={
+            <>
+              매일 아침 내가 가는 역의
+              {"\n"}
+              <Text style={{ color: theme.colors.primary[700] }}>엘리베이터 위치</Text>가 알고 싶다면
+            </>
+          }
           subText="편의시설 정보를 빠르게 확인해보세요"
           buttonText="편의시설 확인하기"
-          onPress={() => console.log('바로가기 눌림')}
+          onPress={() => router.push('/information')}
         />
 
         <Text
@@ -120,24 +126,17 @@ export default function HomeScreen() {
         </Text>
 
         <DirectAccessCard
-          title={`신사역의 혼잡도 알림을\n받고 싶다면?`}
-          subText="알림을 설정 해보세요"
+          title={
+            <>
+              매일 아침 내가 가는 역의
+              {"\n"}
+              혼잡도를 <Text style={{ color: theme.colors.primary[700] }}>알림으로 간단하게</Text>
+            </>
+          }
+          subText="즐겨찾는 역의 혼잡도를 알림으로 받아보세요"
           buttonText="알림 설정하기"
-          onPress={() => console.log('바로가기 눌림')}
+          onPress={() => router.push('/alert')}
         />
-
-        <Text
-          style={[
-            styles.sectionTitle,
-            {
-              color: theme.colors.gray[700],
-              fontFamily: theme.fonts.pretendard.semibold,
-              fontWeight: '600',
-            },
-          ]}
-        >
-          도착역까지 빠른 혼잡도 확인
-        </Text>
       </ScrollView>
     </View>
   );

--- a/app/notice/index.tsx
+++ b/app/notice/index.tsx
@@ -1,7 +1,7 @@
 import Header from '@/components/Header/CommonHeader';
 import NoticeBanner from '@/components/NoticeBanner';
-import { useNoticeContext } from '@/context/NoticeContext'; // ✅ 추가
-import { markNoticeAsRead } from '@/utils/noticeReadStorage'; // ✅ 남겨둠 (상세 이동 시 개별 처리)
+import { useNoticeContext } from '@/context/NoticeContext';
+import { markNoticeAsRead } from '@/utils/noticeReadStorage';
 import { useTheme } from '@emotion/react';
 import dayjs from 'dayjs';
 import { useRouter } from 'expo-router';
@@ -13,7 +13,7 @@ export default function NotificationScreen() {
   const router = useRouter();
   const theme = useTheme();
 
-  const { notices, readIds, refetchNotices } = useNoticeContext(); // ✅ context에서 가져오기
+  const { notices, readIds, refetchNotices } = useNoticeContext(); 
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: '#fff' }} edges={['top', 'bottom']}>
@@ -29,8 +29,8 @@ export default function NotificationScreen() {
           return (
             <TouchableOpacity
               onPress={async () => {
-                await markNoticeAsRead(item.noticeId); // ✅ local 저장
-                await refetchNotices(); // ✅ context 내부 상태 재반영
+                await markNoticeAsRead(item.noticeId);
+                await refetchNotices();
                 router.push(`../notice/${item.noticeId}`);
               }}
             >
@@ -39,7 +39,7 @@ export default function NotificationScreen() {
                 date={dayjs(item.createdAt).format('YYYY. MM. DD. A HH:mm')}
                 backgroundColor={
                   isNew && !isRead
-                    ? theme.colors.primary[100] // ✅ NEW + 미열람: 강조
+                    ? theme.colors.primary[100] 
                     : '#FFF'
                 }
                 textColor={theme.colors.gray[900]}

--- a/components/DirectAccessCard.tsx
+++ b/components/DirectAccessCard.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 interface DirectAccessCardProps {
-  title: string;
+  title: React.ReactNode;
   subText: string;
   buttonText: string;
   onPress: () => void;

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -33,7 +33,7 @@ export default function SearchBar({
             value={value}
             onChangeText={onChangeText}
             placeholderTextColor="#CFCFCF"
-            editable={!onPressInput} // 👈 페이지 이동용이면 입력 비활성화
+            editable={!onPressInput} 
             pointerEvents="none"
           />
         </TouchableOpacity>

--- a/utils/noticeReadStorage.ts
+++ b/utils/noticeReadStorage.ts
@@ -1,16 +1,18 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-const READ_NOTICE_KEY = 'READ_NOTICE_IDS';
+
+const READ_NOTICE_KEY = 'READ_NOTICE_MAP';
 
 export const markNoticeAsRead = async (id: number) => {
   const raw = await AsyncStorage.getItem(READ_NOTICE_KEY);
-  const ids = raw ? JSON.parse(raw) : [];
-  if (!ids.includes(id)) {
-    ids.push(id);
-    await AsyncStorage.setItem(READ_NOTICE_KEY, JSON.stringify(ids));
+  const readMap: Record<number, boolean> = raw ? JSON.parse(raw) : {};
+
+  if (!readMap[id]) {
+    readMap[id] = true;
+    await AsyncStorage.setItem(READ_NOTICE_KEY, JSON.stringify(readMap));
   }
 };
 
-export const getReadNoticeIds = async (): Promise<number[]> => {
+export const getReadNoticeMap = async (): Promise<Record<number, boolean>> => {
   const raw = await AsyncStorage.getItem(READ_NOTICE_KEY);
-  return raw ? JSON.parse(raw) : [];
+  return raw ? JSON.parse(raw) : {};
 };


### PR DESCRIPTION
🔧 공지 읽음 상태 저장 방식 리팩터링

- 기존: readIds: number[] 배열 기반
- 변경: readMap: Record<number, boolean> 기반으로 구조 변경

📌 변경 이유

- 읽음 여부 조회 시 매번 includes() 호출로 인한 성능 저하 방지
- 확장성과 유지보수 측면에서 Map 기반이 유리

✅ 주요 변경 사항

- utils/noticeReadStorage.ts: 읽음 저장 및 조회 로직 Map 기반으로 변경
- context/NoticeContext.tsx: readIds 대신 readMap을 중심으로 상태 관리
- 하위 컴포넌트에서는 기존 인터페이스를 유지하기 위해 readIds도 호환성 유지

**- 알림설정 웨더헤더 알람닷 prop전달**
**- 홈화면 멘트 수정 및 버튼 바로가기 구현**
