### PR TITLE
feat: 홈화면 즐겨찾기 카드 클릭시 혼잡도 상세 페이지로 이동

### DIFF
--- a/app/(tabs)/congestion/first-result/index.tsx
+++ b/app/(tabs)/congestion/first-result/index.tsx
@@ -9,7 +9,12 @@ import StationInfo from '@/components/StationInfo';
 import ToggleBox from '@/components/ToggleBox';
 import { useStationContext } from '@/context/StationContext';
 import { theme } from '@/styles/theme';
-import { StationDetail, StationResult, StationStatusCongestion, StationStatusWeather } from '@/types/station';
+import {
+  StationDetail,
+  StationResult,
+  StationStatusCongestion,
+  StationStatusWeather,
+} from '@/types/station';
 import { getDateLabelFromDate, getDayjsFromDateLabel } from '@/utils/dateLabel';
 import { getCongestionStyle } from '@/utils/getCongestionStyle';
 import { getWeatherStyle } from '@/utils/getWeatherStyle';
@@ -19,13 +24,22 @@ import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import dayjs from 'dayjs';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Dimensions, Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Dimensions,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function FirstResultScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const theme=useTheme();
+  const theme = useTheme();
   const { station, line, date, time } = useLocalSearchParams<{
     station: string;
     line: string;
@@ -41,20 +55,28 @@ export default function FirstResultScreen() {
 
   const [address, setAddress] = useState('');
   const [phoneNumber, setPhoneNumber] = useState('');
-  const [selectedButton, setSelectedButton] = useState<'상행' | '하행' | '외선' | '내선' | null>(null);
+  const [selectedButton, setSelectedButton] = useState<'상행' | '하행' | '외선' | '내선' | null>(
+    null,
+  );
   const [directionKeys, setDirectionKeys] = useState<('상행' | '하행' | '외선' | '내선')[]>([]);
   const [selectedDate, setSelectedDate] = useState<'오늘' | '내일' | '모레'>('오늘');
-  const [statusData, setStatusData] = useState<{
-  [key in '상행' | '하행' | '외선' | '내선']?: {
-    weathers: StationStatusWeather[];
-    congestions: StationStatusCongestion[];
-  }
-} | null>(null);
+  const [statusData, setStatusData] = useState<
+    | {
+        [key in '상행' | '하행' | '외선' | '내선']?: {
+          weathers: StationStatusWeather[];
+          congestions: StationStatusCongestion[];
+        };
+      }
+    | null
+  >(null);
 
   useEffect(() => {
     if (result) {
       const keys = Object.keys(result.congestionByDirection || {}) as (
-        '상행' | '하행' | '외선' | '내선'
+        | '상행'
+        | '하행'
+        | '외선'
+        | '내선'
       )[];
       setDirectionKeys(keys);
       if (keys.length > 0) {
@@ -64,48 +86,48 @@ export default function FirstResultScreen() {
   }, [result]);
 
   useEffect(() => {
-  const fetchData = async () => {
-    if (!station || !line || !date || !time) {
-      setLoading(false);
-      return;
-    }
-    
-    const stationId = getStationIdByNameAndLine(station, line);
-    if (!stationId) {
-      setLoading(false);
-      return;
-    }
-   console.log('📦 stationId:', stationId);
-   console.log('⏰ 요청 시간 (원본):', time);
-    try {
-      const [res, detailRes,statusRes] = await Promise.all([
-        fetchStationByIdAndTime({ stationId, time: time as string }),
-        fetchStationDetailInfo(),
-        fetchStationStatus(stationId)
-      ]);
-      
-      setResult(res);
-      setStatusData(statusRes.result);
-     
-      const matchedDetails = detailRes.result.filter(
-        (item: StationDetail) => item.stationName === station
-      );
-      const base = matchedDetails.reduce<StationDetail | null>(
-        (min, curr) => !min || curr.stationId < min.stationId ? curr : min,
-        null
-      );
+    const fetchData = async () => {
+      if (!station || !line || !date || !time) {
+        setLoading(false);
+        return;
+      }
 
-      setAddress(base?.address ?? '아직 주소를 업데이트하고 있어요');
-      setPhoneNumber(base?.phoneNumber ?? '02-0000-0000');
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setLoading(false);
-    }
-  };
-  
-  fetchData();
-}, [station, line, date, time]);
+      const stationId = getStationIdByNameAndLine(station, line);
+      if (!stationId) {
+        setLoading(false);
+        return;
+      }
+      console.log('📦 stationId:', stationId);
+      console.log('⏰ 요청 시간 (원본):', time);
+      try {
+        const [res, detailRes, statusRes] = await Promise.all([
+          fetchStationByIdAndTime({ stationId, time: time as string }),
+          fetchStationDetailInfo(),
+          fetchStationStatus(stationId),
+        ]);
+
+        setResult(res);
+        setStatusData(statusRes.result);
+
+        const matchedDetails = detailRes.result.filter(
+          (item: StationDetail) => item.stationName === station,
+        );
+        const base = matchedDetails.reduce<StationDetail | null>(
+          (min, curr) => (!min || curr.stationId < min.stationId ? curr : min),
+          null,
+        );
+
+        setAddress(base?.address ?? '아직 주소를 업데이트하고 있어요');
+        setPhoneNumber(base?.phoneNumber ?? '02-0000-0000');
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [station, line, date, time]);
 
   useEffect(() => {
     if (!loading && bottomSheetRef.current) {
@@ -118,65 +140,66 @@ export default function FirstResultScreen() {
       return (
         <>
           <Text>❌ 결과를 불러오지 못했습니다.</Text>
-          <Text>{station} / {line}</Text>
+          <Text>
+            {station} / {line}
+          </Text>
         </>
       );
     }
 
-  const filterStatusByDate = (
-  label: '오늘' | '내일' | '모레',
-  direction: '상행' | '하행' | '외선' | '내선'
-  ) => {
-    if (!statusData || !statusData[direction]) return [];
+    const filterStatusByDate = (
+      label: '오늘' | '내일' | '모레',
+      direction: '상행' | '하행' | '외선' | '내선',
+    ) => {
+      if (!statusData || !statusData[direction]) return [];
 
-    const { weathers, congestions } = statusData[direction];
-    const targetDate = getDayjsFromDateLabel(label);
+      const { weathers, congestions } = statusData[direction];
+      const targetDate = getDayjsFromDateLabel(label);
 
-    return weathers
-      .filter(w => dayjs(w.datetime).isSame(targetDate, 'day'))
-      .map(w => {
-        const match = congestions.find(c => dayjs(c.datetime).isSame(w.datetime));
-        return {
-          time: dayjs(w.datetime).format('HH시'),
-          rate: match?.prediction.congestionScore ?? '정보 없음',
-          level: match?.prediction.congestionLevel ?? '정보 없음',
-        };
-      });
-  };
+      return weathers
+        .filter(w => dayjs(w.datetime).isSame(targetDate, 'day'))
+        .map(w => {
+          const match = congestions.find(c => dayjs(c.datetime).isSame(w.datetime));
+          return {
+            time: dayjs(w.datetime).format('HH시'),
+            rate: match?.prediction.congestionScore ?? '정보 없음',
+            level: match?.prediction.congestionLevel ?? '정보 없음',
+          };
+        });
+    };
 
     const selectedDateObj = dayjs(time);
     const dateLabel = getDateLabelFromDate(selectedDateObj);
     const hourStr = selectedDateObj.format('HH');
     const formattedTime = `${dateLabel} ${hourStr}:00`;
 
-
     const filterWeatherByDate = (
-    label: '오늘' | '내일' | '모레',
-    direction: '상행' | '하행' | '외선' | '내선'
-  ) => {
-    if (!statusData || !statusData[direction]) return [];
+      label: '오늘' | '내일' | '모레',
+      direction: '상행' | '하행' | '외선' | '내선',
+    ) => {
+      if (!statusData || !statusData[direction]) return [];
 
-    const targetDate = getDayjsFromDateLabel(label);
+      const targetDate = getDayjsFromDateLabel(label);
 
-    return statusData[direction].weathers
-      .filter(w => dayjs(w.datetime).isSame(targetDate, 'day'))
-      .map(w => ({
-        time: dayjs(w.datetime).format('HH시'),
-        status: w.weather.status,
-        tmp: w.weather.tmp,
-      }));
-  };
+      return statusData[direction].weathers
+        .filter(w => dayjs(w.datetime).isSame(targetDate, 'day'))
+        .map(w => ({
+          time: dayjs(w.datetime).format('HH시'),
+          status: w.weather.status,
+          tmp: w.weather.tmp,
+        }));
+    };
 
     return (
       <>
-      <StationHeader
+        <StationHeader
           stationName={result.name}
           lines={[result.line]}
           address={address}
           phoneNumber={phoneNumber}
-        /> 
+        />
         <View style={[styles.clickBox, { backgroundColor: theme.colors.gray[0] }]}>
-          {directionKeys.map((dirKey) => (
+          {directionKeys.map(dirKey => (
             <TouchableOpacity
               key={dirKey}
               style={[
@@ -190,9 +213,7 @@ export default function FirstResultScreen() {
                   styles.buttonText,
                   {
                     color:
-                      selectedButton === dirKey
-                        ? theme.colors.gray[800]
-                        : theme.colors.gray[400],
+                      selectedButton === dirKey ? theme.colors.gray[800] : theme.colors.gray[400],
                   },
                 ]}
               >
@@ -213,8 +234,11 @@ export default function FirstResultScreen() {
             return <Text>⚠️ {selectedButton} 방향 정보 없음</Text>;
           }
 
-        const { textColor, backgroundColor, topText } = getCongestionStyle(congestion.congestionLevel, theme);
-        return (
+          const { textColor, backgroundColor, topText } = getCongestionStyle(
+            congestion.congestionLevel,
+            theme,
+          );
+          return (
             <InfoBox
               key={selectedButton}
               specialColor={textColor}
@@ -226,52 +250,54 @@ export default function FirstResultScreen() {
             />
           );
         })()}
-        
+
         <ToggleBox
-        text="지하철 혼잡도 예측"
-        defaultSelected="오늘"
-        onSelect={(val) => setSelectedDate(val)}
-      />
+          text="지하철 혼잡도 예측"
+          defaultSelected="오늘"
+          onSelect={val => setSelectedDate(val)}
+        />
 
-      {selectedButton && (
-        <View style={{flex: 1, backgroundColor: theme.colors.gray[0], marginBottom: px(4)}}> 
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{
-              backgroundColor: theme.colors.gray[0],
-              flexDirection: 'row',
-              gap: px(8),
-              paddingHorizontal: wp(24),
-              paddingTop: hp(12),
-              paddingBottom: hp(34),
-              alignItems: 'center'
-            }}
-          >
-            {filterStatusByDate(selectedDate, selectedButton).map((item, idx) => {
-              const { textColor } = getCongestionStyle(item.level, theme);
+        {selectedButton && (
+          <View style={{ flex: 1, backgroundColor: theme.colors.gray[0], marginBottom: px(4) }}>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={{
+                backgroundColor: theme.colors.gray[0],
+                flexDirection: 'row',
+                gap: px(8),
+                paddingHorizontal: wp(24),
+                paddingTop: hp(12),
+                paddingBottom: hp(34),
+                alignItems: 'center',
+              }}
+            >
+              {filterStatusByDate(selectedDate, selectedButton).map((item, idx) => {
+                const { textColor } = getCongestionStyle(item.level, theme);
 
-              return (
-                <SmallInfoBox
-                  key={idx}
-                  time={item.time}
-                  image={require('@/assets/images/Multiply.png')}
-                  text1={item.level}
-                  text2={`${item.rate}%`}
-                  textColor={textColor}
-                />
-              );
-            })}
-          </ScrollView>        
-        </View>
-      )}
-
+                return (
+                  <SmallInfoBox
+                    key={idx}
+                    time={item.time}
+                    image={require('@/assets/images/Multiply.png')}
+                    text1={item.level}
+                    text2={`${item.rate}%`}
+                    textColor={textColor}
+                  />
+                );
+              })}
+            </ScrollView>
+          </View>
+        )}
 
         {(() => {
           if (!result || !result.weather) return null;
 
           const weather = result.weather;
-          const { textColor, backgroundColor, topText } = getWeatherStyle(weather.status ?? '', theme);
+          const { textColor, backgroundColor, topText } = getWeatherStyle(
+            weather.status ?? '',
+            theme,
+          );
 
           return (
             <InfoBox
@@ -289,68 +315,68 @@ export default function FirstResultScreen() {
         <View style={styles.weatherContainer}>
           {result.weather ? (
             <>
-          <View style={styles.weatherBox}>
-            <Image
-              style={styles.weatherIconContainer}
-              source={require('@/assets/images/Multiply.png')}
-            />
-            <Text style={styles.weatherText}>기온</Text>
-            <Text style={styles.weatherValueText}>{result.weather.tmp ?? '--'}℃</Text>
-          </View>
-          <View style={styles.weatherBox}>
-            <Image
-              style={styles.weatherIconContainer}
-              source={require('@/assets/images/Multiply.png')}
-            />
-            <Text style={styles.weatherText}>강수량</Text>
-            <Text style={styles.weatherValueText}>{result.weather.pcp ?? '--'}mm</Text>
-          </View>
-          <View style={styles.weatherBox}>
-            <Image
-              style={styles.weatherIconContainer}
-              source={require('@/assets/images/Multiply.png')}
-            />
-            <Text style={styles.weatherText}>습도</Text>
-            <Text style={styles.weatherValueText}>{result.weather.reh ?? '--'}%</Text>
-          </View>
-          <View style={styles.weatherBox}>
-            <Image
-              style={styles.weatherIconContainer}
-              source={require('@/assets/images/Multiply.png')}
-            />
-            <Text style={styles.weatherText}>적설</Text>
-            <Text style={styles.weatherValueText}>{result.weather.sno ?? '--'}mm</Text>
-          </View>
-          <View style={styles.weatherBox}>
-            <Image
-              style={styles.weatherIconContainer}
-              source={require('@/assets/images/Multiply.png')}
-            />
-            <Text style={styles.weatherText}>풍향</Text>
-            <Text style={styles.weatherValueText}>{result.weather.vec ?? '--'}°</Text>
-          </View>
-          <View style={styles.weatherBox}>
-            <Image
-              style={styles.weatherIconContainer}
-              source={require('@/assets/images/Multiply.png')}
-            />
-            <Text style={styles.weatherText}>풍속</Text>
-            <Text style={styles.weatherValueText}>{result.weather.wsd ?? '--'}m/s</Text>
-          </View>
+              <View style={styles.weatherBox}>
+                <Image
+                  style={styles.weatherIconContainer}
+                  source={require('@/assets/images/Multiply.png')}
+                />
+                <Text style={styles.weatherText}>기온</Text>
+                <Text style={styles.weatherValueText}>{result.weather.tmp ?? '--'}℃</Text>
+              </View>
+              <View style={styles.weatherBox}>
+                <Image
+                  style={styles.weatherIconContainer}
+                  source={require('@/assets/images/Multiply.png')}
+                />
+                <Text style={styles.weatherText}>강수량</Text>
+                <Text style={styles.weatherValueText}>{result.weather.pcp ?? '--'}mm</Text>
+              </View>
+              <View style={styles.weatherBox}>
+                <Image
+                  style={styles.weatherIconContainer}
+                  source={require('@/assets/images/Multiply.png')}
+                />
+                <Text style={styles.weatherText}>습도</Text>
+                <Text style={styles.weatherValueText}>{result.weather.reh ?? '--'}%</Text>
+              </View>
+              <View style={styles.weatherBox}>
+                <Image
+                  style={styles.weatherIconContainer}
+                  source={require('@/assets/images/Multiply.png')}
+                />
+                <Text style={styles.weatherText}>적설</Text>
+                <Text style={styles.weatherValueText}>{result.weather.sno ?? '--'}mm</Text>
+              </View>
+              <View style={styles.weatherBox}>
+                <Image
+                  style={styles.weatherIconContainer}
+                  source={require('@/assets/images/Multiply.png')}
+                />
+                <Text style={styles.weatherText}>풍향</Text>
+                <Text style={styles.weatherValueText}>{result.weather.vec ?? '--'}°</Text>
+              </View>
+              <View style={styles.weatherBox}>
+                <Image
+                  style={styles.weatherIconContainer}
+                  source={require('@/assets/images/Multiply.png')}
+                />
+                <Text style={styles.weatherText}>풍속</Text>
+                <Text style={styles.weatherValueText}>{result.weather.wsd ?? '--'}m/s</Text>
+              </View>
             </>
           ) : (
             <Text>날씨 데이터가 없습니다.</Text>
           )}
         </View>
 
-         <ToggleBox
+        <ToggleBox
           text="날씨 예측 정보"
           defaultSelected="오늘"
-          onSelect={(val) => setSelectedDate(val)}
+          onSelect={val => setSelectedDate(val)}
         />
 
         {selectedButton && (
-          <View style={{flex: 1, backgroundColor: theme.colors.gray[0], marginBottom: px(4)}}> 
+          <View style={{ flex: 1, backgroundColor: theme.colors.gray[0], marginBottom: px(4) }}>
             <ScrollView
               horizontal
               showsHorizontalScrollIndicator={false}
@@ -361,7 +387,7 @@ export default function FirstResultScreen() {
                 paddingHorizontal: wp(24),
                 paddingTop: hp(12),
                 paddingBottom: hp(34),
-                alignItems: 'center'
+                alignItems: 'center',
               }}
             >
               {filterWeatherByDate(selectedDate, selectedButton).map((item, idx) => {
@@ -378,43 +404,41 @@ export default function FirstResultScreen() {
                   />
                 );
               })}
-            </ScrollView>        
+            </ScrollView>
           </View>
         )}
-        
 
-        <StationInfo/>
-
+        <StationInfo />
       </>
     );
   };
-      const [isDismissed, setIsDismissed] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
 
-    useEffect(() => {
-  if (!loading && bottomSheetRef.current && isDismissed) {
-    // dismiss되었다가 다시 띄워야 할 때
-    setIsDismissed(false); // 먼저 false로 바꿔주고
-    bottomSheetRef.current.present(); // 다시 열기
-  } else if (!loading && bottomSheetRef.current && !isDismissed) {
-    bottomSheetRef.current.present(); // 최초 진입
-  }
-}, [loading, isDismissed]);
+  useEffect(() => {
+    if (!loading && bottomSheetRef.current && isDismissed) {
+      // dismiss되었다가 다시 띄워야 할 때
+      setIsDismissed(false); // 먼저 false로 바꿔주고
+      bottomSheetRef.current.present(); // 다시 열기
+    } else if (!loading && bottomSheetRef.current && !isDismissed) {
+      bottomSheetRef.current.present(); // 최초 진입
+    }
+  }, [loading, isDismissed]);
 
-    const handleDismiss = () => {
-      setIsDismissed(true);
-    };
+  const handleDismiss = () => {
+    setIsDismissed(true);
+  };
 
-    const { height: SCREEN_HEIGHT, width: SCREEN_WIDTH } = Dimensions.get('window');
-    const safeHeight = SCREEN_HEIGHT - insets.top - insets.bottom;
-    const imageHeight = safeHeight;
-    const imageWidth = (4635 / 3685) * imageHeight;
+  const { height: SCREEN_HEIGHT, width: SCREEN_WIDTH } = Dimensions.get('window');
+  const safeHeight = SCREEN_HEIGHT - insets.top - insets.bottom;
+  const imageHeight = safeHeight;
+  const imageWidth = (4635 / 3685) * imageHeight;
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
       <Header
-        title='상세정보'
+        title="상세정보"
         showLeft={true}
-        onPressLeft={() => router.back()}
+        onPressLeft={() => router.replace('/congestion')}
         rightType="close"
         onPressRight={() => router.replace('/congestion')}
       />
@@ -430,10 +454,7 @@ export default function FirstResultScreen() {
         bounces={false}
         horizontal={true}
       >
-        <ScrollView
-          contentContainerStyle={{ flexGrow: 1 }}
-          showsVerticalScrollIndicator={false}
-        >
+        <ScrollView contentContainerStyle={{ flexGrow: 1 }} showsVerticalScrollIndicator={false}>
           <Image
             source={subwayImage}
             style={{
@@ -446,7 +467,7 @@ export default function FirstResultScreen() {
       </ScrollView>
 
       {loading ? (
-        <View style={{ marginTop: 100 , alignItems:'center'}}>
+        <View style={{ marginTop: 100, alignItems: 'center' }}>
           <ActivityIndicator size="large" />
           <Text>결과를 불러오는 중입니다...</Text>
         </View>
@@ -457,9 +478,9 @@ export default function FirstResultScreen() {
           snapPoints={snapPoints}
           onDismiss={handleDismiss}
         >
-            <BottomSheetScrollView style={{backgroundColor:theme.colors.gray[100]}}>
-              {renderBottomSheetContent()}
-            </BottomSheetScrollView>
+          <BottomSheetScrollView style={{ backgroundColor: theme.colors.gray[100] }}>
+            {renderBottomSheetContent()}
+          </BottomSheetScrollView>
         </BottomSheetModal>
       )}
     </View>
@@ -472,17 +493,23 @@ const styles = StyleSheet.create({
     backgroundColor: '#FFF',
   },
 
-  directionBlock: { marginBottom: 16, paddingVertical: 8},
+  directionBlock: { marginBottom: 16, paddingVertical: 8 },
 
   directionTitle: { fontSize: 18, fontWeight: '600', marginBottom: 4 },
 
   weatherBlock: { marginTop: 24, paddingTop: 8, borderTopWidth: 1, borderColor: '#ddd' },
 
   weatherTitle: { fontSize: 18, fontWeight: '600', marginBottom: 6 },
-  
+
   buttonRow: { flexDirection: 'row', justifyContent: 'space-between', marginTop: 24, gap: 12 },
 
-  setButton: { flex: 1, backgroundColor: '#F2F2F2', paddingVertical: 12, borderRadius: 8, alignItems: 'center' },
+  setButton: {
+    flex: 1,
+    backgroundColor: '#F2F2F2',
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
 
   setButtonText: { fontSize: 16, fontWeight: '600', color: '#333' },
 
@@ -490,23 +517,52 @@ const styles = StyleSheet.create({
 
   mapZoomContainer: { flexGrow: 1, alignItems: 'center', justifyContent: 'center' },
 
-  stationBox: { height: hp(98), paddingHorizontal: wp(24), flexDirection: 'column', justifyContent: 'center', alignItems: 'center', alignSelf: 'stretch' },
+  stationBox: {
+    height: hp(98),
+    paddingHorizontal: wp(24),
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    alignSelf: 'stretch',
+  },
 
-  centerStationBox: { width: wp(262), height: hp(60), paddingHorizontal: wp(24), justifyContent: 'center', alignItems: 'center', gap: px(10), borderRadius: 999, borderWidth: px(8), shadowColor: 'rgba(0, 0, 0, 0.05)', shadowOffset: { width: 4, height: 4 }, shadowOpacity: 1, shadowRadius: 4, elevation: 4 },
-  
+  centerStationBox: {
+    width: wp(262),
+    height: hp(60),
+    paddingHorizontal: wp(24),
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: px(10),
+    borderRadius: 999,
+    borderWidth: px(8),
+    shadowColor: 'rgba(0, 0, 0, 0.05)',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 1,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+
   centerStationWrapper: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center' },
 
-  TailBox: { position: 'absolute', top: '50%', transform: [{ translateY: -hp(20) }], width: '100%', height: hp(40), borderRadius: px(999), zIndex: 0 },
-  
-  clickBox:{
-  flexDirection: 'row',
-  paddingTop: hp(30),
-  paddingRight: wp(24),
-  paddingBottom: hp(24),
-  paddingLeft: wp(24),
-  alignItems: 'flex-start',
-  alignSelf: 'stretch',
-},
+  TailBox: {
+    position: 'absolute',
+    top: '50%',
+    transform: [{ translateY: -hp(20) }],
+    width: '100%',
+    height: hp(40),
+    borderRadius: px(999),
+    zIndex: 0,
+  },
+
+  clickBox: {
+    flexDirection: 'row',
+    paddingTop: hp(30),
+    paddingRight: wp(24),
+    paddingBottom: hp(24),
+    paddingLeft: wp(24),
+    alignItems: 'flex-start',
+    alignSelf: 'stretch',
+  },
   button: {
     height: px(60),
     paddingVertical: px(12),
@@ -514,10 +570,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     gap: px(15),
-    flex: 1, 
-    borderRadius:px(9),
+    flex: 1,
+    borderRadius: px(9),
     borderWidth: px(3),
-    marginTop:20
+    marginTop: 20,
   },
   selected: {
     borderColor: '#E5E5E5',
@@ -530,17 +586,17 @@ const styles = StyleSheet.create({
   buttonText: {
     fontSize: px(22),
     fontWeight: '600',
-    fontFamily:'Pretendard-SemiBold',
-    lineHeight:px(30)
+    fontFamily: 'Pretendard-SemiBold',
+    lineHeight: px(30),
   },
-  weatherContainer:{
-    backgroundColor:theme.colors.gray[50],
-    padding:px(24),
-    flexDirection:'row',
-    justifyContent:'center',
-    alignItems:'center',
-    gap:px(10),
-    alignSelf:'stretch',
+  weatherContainer: {
+    backgroundColor: theme.colors.gray[50],
+    padding: px(24),
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: px(10),
+    alignSelf: 'stretch',
   },
   weatherBox: {
     flexDirection: 'column',

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -34,3 +34,67 @@ export function formatKSTRoundedHour(date = new Date()) {
 
   return `${pad(month)}/${pad(day)} ${pad(hour)}:00 기준`;
 }
+
+// 혼잡도 API 파라미터용 KST 날짜/시간 ISO String 포맷 함수 (단일 함수)
+export function getKSTCongestionDateTimeISOString(baseDate = new Date()): string {
+  // 1. 현재 Date 객체를 KST 기준으로 변환 (정보 추출용)
+  // getTime()은 UTC 경과 밀리초를 반환. getTimezoneOffset()은 로컬 시간과 UTC의 차이 (분)
+  // KST는 UTC+9. 따라서 로컬 시간 + 로컬 오프셋 + 9시간 = KST 밀리초
+  const kstTimeMs =
+    baseDate.getTime() + baseDate.getTimezoneOffset() * 60 * 1000 + 9 * 60 * 60 * 1000;
+  const kstDateTime = new Date(kstTimeMs); // KST 시간으로 설정된 Date 객체 (정보 추출용)
+
+  let year = kstDateTime.getFullYear();
+  let month = kstDateTime.getMonth(); // getMonth()는 0-기반 (0:1월, 11:12월)
+  let day = kstDateTime.getDate();
+  let hour = kstDateTime.getHours(); // KST 기준 현재 시
+  const minutes = kstDateTime.getMinutes();
+  const seconds = kstDateTime.getSeconds();
+
+  // console.log(`[1. KST 추출]: ${year}년 ${month + 1}월 ${day}일 ${hour}시 ${minutes}분 ${seconds}초 (KST)`);
+
+  // 2. 시간 반올림/고정 로직 적용
+  if ((hour >= 1 && hour <= 4) || (hour === 0 && (minutes > 0 || seconds > 0))) {
+    hour = 5;
+    // console.log('[2. 로직 적용]: 시간 5시로 고정');
+  } else {
+    if (minutes > 0 || seconds > 0) {
+      hour += 1;
+      // console.log(`[2. 로직 적용]: 시간 1시간 증가 -> ${hour}시`);
+    }
+  }
+
+  // 3. 24시 초과 시 날짜 조정 (새로운 Date 객체 생성 없이 변수만 조정)
+  if (hour >= 24) {
+    hour -= 24; // 시간을 0-23 범위로 리셋
+
+    // 날짜를 하루 증가시키기 위해 임시 Date 객체를 사용하고,
+    // 그 객체에서 변경된 년, 월, 일을 다시 가져옵니다.
+    // 이는 윤년, 월말 처리 등을 Date 객체가 알아서 처리하도록 하기 위함입니다.
+    const tempDateForDayChange = new Date(year, month, day); // month는 0-기반 그대로
+    tempDateForDayChange.setDate(tempDateForDayChange.getDate() + 1); // 하루 증가
+
+    year = tempDateForDayChange.getFullYear();
+    month = tempDateForDayChange.getMonth(); // 0-기반 월
+    day = tempDateForDayChange.getDate();
+    // console.log(`[3. 날짜 조정]: 다음 날로 변경 -> ${year}년 ${month + 1}월 ${day}일`);
+  }
+
+  // console.log(`[4. 최종 KST 값]: ${year}년 ${month + 1}월 ${day}일 ${hour}시 00분 00초 (KST)`);
+
+  // 5. 수동으로 ISO String 형식 생성
+  const pad = (num: number) => num.toString().padStart(2, '0');
+
+  const formattedYear = year;
+  const formattedMonth = pad(month + 1); // 월은 다시 1 더해서 01-12 형식으로
+  const formattedDay = pad(day);
+  const formattedHour = pad(hour);
+  const formattedMinute = pad(0); // 분, 초는 00으로 고정
+  const formattedSecond = pad(0);
+
+  // YYYY-MM-DDTHH:MM:SS 형식의 문자열 조합
+  const isoString = `${formattedYear}-${formattedMonth}-${formattedDay}T${formattedHour}:${formattedMinute}:${formattedSecond}`;
+
+  // console.log('[5. 최종 ISO String]:', isoString);
+  return isoString;
+}


### PR DESCRIPTION
## ✨ 기능 추가

### 홈화면 즐겨찾기 카드 → 혼잡도 상세 페이지 이동
- 홈화면에서 즐겨찾기한 역의 혼잡도 카드를 클릭하면 상세 페이지로 이동
- 해당 시간(`홈 화면 카드에 노출된 시간`)을 기반으로 상세 페이지 요청 수행

---

## 🔧 구현 상세

### 1. 시간 변환 유틸 함수 추가
- `getKSTCongestionDateTimeISOString` 함수 구현
  - 홈 화면에서 넘긴 시간 값을 KST 기준 ISO 문자열로 변환
  - 혼잡도 상세 페이지에서 API 요청 시 사용

### 2. 혼잡도 상세 페이지 params 전달
- 홈 → 상세 페이지 이동 시 `역 ID`, `시간`을 `params`로 전달
  - 시간은 변환된 KST ISO 형식으로 전달됨

---

## 🐞 버그 수정

### 혼잡도 상세 페이지 뒤로가기 시 바텀시트 미사라짐 이슈
- 기존: 뒤로가기 버튼 클릭 시 바텀시트가 열린 상태로 유지됨
- 수정: 헤더 뒤로가기 시 명시적으로 `/congestion` 경로로 이동 → 바텀시트 자동 해제됨

---

## ✅ 테스트 체크리스트
- [x] 즐겨찾기 카드 클릭 → 상세 페이지 정상 이동
- [x] 현재 이후 정각 시간이 혼잡도 상세 페이지 시간에 뜨는지 확인
- [x] 상세 페이지 → 뒤로가기 시 바텀시트가 사라지는지 확인
- [x] 뒤로가기 시 URL이 `/congestion`으로 정상 변경되는지 확인
