### PR TITLE
feat: 로그아웃 API 연동

### DIFF
--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -1,4 +1,9 @@
-import { FetchUserResponse, KakaoLoginRequest, KakaoLoginResponse } from '../types/auth';
+import {
+  FetchUserResponse,
+  KakaoLoginRequest,
+  KakaoLoginResponse,
+  LogoutResponse,
+} from '../types/auth';
 import { axiosInstance } from './axios';
 
 export const loginKakao = async (body: KakaoLoginRequest): Promise<KakaoLoginResponse> => {
@@ -8,5 +13,10 @@ export const loginKakao = async (body: KakaoLoginRequest): Promise<KakaoLoginRes
 
 export const fetchUser = async (): Promise<FetchUserResponse> => {
   const { data } = await axiosInstance.get('/api/users/me');
+  return data;
+};
+
+export const logout = async (): Promise<LogoutResponse> => {
+  const { data } = await axiosInstance.post('/api/auth/logout');
   return data;
 };

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -33,3 +33,5 @@ export type KakaoLoginResponse = CommonResponse<{
 }>;
 
 export type FetchUserResponse = CommonResponse<UserProfile>;
+
+export type LogoutResponse = CommonResponse<{}>;


### PR DESCRIPTION
### 📌 주요 변경 사항

- `apis/auth.ts`에 `logout()` API 함수 추가
- 서버 응답 타입 `LogoutResponse` 정의
- 클라이언트 로그아웃 흐름에 API 연동 적용
- 기존 로그아웃 로직에 에러 핸들링(`try-catch`) 적용 및 순서 개선

---

### 테스트 방법
`context/AuthContext.tsx`
```ts
 const logout = async () => {
    try {
      await logoutApi(); // 이 부분을 const res = await logoutApi(); console.log(res) 로 변경해주세요!
      setUser(null);
      await Promise.all([
        SecureStore.deleteItemAsync('accessToken'),
        SecureStore.deleteItemAsync('refreshToken'),
        AsyncStorage.removeItem('user'),
      ]);
    } catch (error) {
      console.error('로그아웃 중 에러 발생:', error);
      Alert.alert('로그아웃 실패', '다시 시도해 주세요.');
    }
  };
```
코드를 변경하고 로그아웃 버튼을 눌렀을 때 서버 응답이 정상적으로 오는 것을 확인해주세요!
