### PR TITLE
feat: 홈화면 마운트시 푸시토큰 전송

### DIFF
--- a/apis/alarm.ts
+++ b/apis/alarm.ts
@@ -7,7 +7,15 @@ import {
   UpdateAlarmRequest,
   UpdateAlarmResponse,
 } from '@/types/alarm';
+import { CommonResponse } from '@/types/common';
 import { axiosInstance } from './axios';
+
+export const sendPushToken = async (pushToken: string): Promise<CommonResponse<{}>> => {
+  const { data } = await axiosInstance.post('/api/users/me/pushtokens', null, {
+    params: { pushToken },
+  });
+  return data;
+};
 
 export const readAlarmList = async (): Promise<ReadAlarmResponse> => {
   const { data } = await axiosInstance.get('/api/users/me/alarms');

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,14 +8,13 @@ import { ThemeProvider } from '@emotion/react';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { Asset } from 'expo-asset';
 import Constants from 'expo-constants';
-import * as Device from 'expo-device';
 import * as Font from 'expo-font';
 import { Image } from 'expo-image';
 import * as Notifications from 'expo-notifications';
 import { Stack, useRouter } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import React, { useEffect, useRef, useState } from 'react';
-import { Alert, Animated, Linking, StyleSheet, View } from 'react-native';
+import { Animated, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ko, registerTranslation } from 'react-native-paper-dates';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -58,31 +57,10 @@ function AnimatedAppLoader({ children, image }: { children: React.ReactNode; ima
   return <AnimatedSplashScreen image={image}>{children}</AnimatedSplashScreen>;
 }
 
-async function sendPushNotification(expoPushToken: string) {
-  const message = {
-    to: expoPushToken,
-    sound: 'default',
-    title: 'Original Title',
-    body: 'And here is the body!',
-    data: { someData: 'goes here' },
-  };
-
-  await fetch('https://exp.host/--/api/v2/push/send', {
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      'Accept-encoding': 'gzip, deflate',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(message),
-  });
-}
-
 function AnimatedSplashScreen({ children, image }: { children: React.ReactNode; image: number }) {
   const [isAppReady, setAppReady] = useState(false);
   const [isSplashAnimationComplete, setSplashAnimationComplete] = useState(false);
   const animation = useRef(new Animated.Value(1)).current;
-  const [expoPushToken, setExpoPushToken] = useState<string | null>(null);
 
   useEffect(() => {
     if (isAppReady) {
@@ -94,31 +72,10 @@ function AnimatedSplashScreen({ children, image }: { children: React.ReactNode; 
     }
   }, [isAppReady]);
 
-  useEffect(() => {
-    if (expoPushToken && Device.isDevice) {
-      sendPushNotification(expoPushToken);
-    }
-  }, [expoPushToken]);
-
   const onImageLoaded = async () => {
     try {
-      // 데이터 준비
       await Promise.all([]);
       await SplashScreen.hideAsync();
-      const { status } = await Notifications.requestPermissionsAsync();
-      if (status !== Notifications.PermissionStatus.GRANTED) {
-        Alert.alert('알림 권한 필요', '알림을 받기 위해 권한을 허용해주세요.', [
-          { text: '취소', style: 'cancel' },
-          { text: '설정으로 이동', onPress: () => Linking.openSettings() },
-        ]);
-        return;
-      }
-      const token = await Notifications.getExpoPushTokenAsync({
-        projectId: Constants.expoConfig?.extra?.eas?.projectId ?? Constants.easConfig?.projectId,
-      });
-      console.log('✅ 푸시 토큰:', token);
-      // TODO: save token to server
-      setExpoPushToken(token.data);
     } catch (error) {
       console.error(error);
     } finally {


### PR DESCRIPTION
### 변경사항
- 홈화면 마운트시 알림 권한 허용 알림이 뜨고, 이후 홈화면이 새로 마운트 될때마다 푸시토큰이 서버에 전송됩니다.

### 테스트 코드
- tabs/index.tsx 내의 sendExpoPushToken 함수를 다음과 같이 수정
```tsx
  const sendExpoPushToken = async () => {
    const { status } = await Notifications.requestPermissionsAsync();
    if (status !== Notifications.PermissionStatus.GRANTED) {
      Alert.alert('알림 권한 필요', '알림을 받기 위해 권한을 허용해주세요.', [
        { text: '취소', style: 'cancel' },
        { text: '설정으로 이동', onPress: () => Linking.openSettings() },
      ]);
      return;
    }
    const token = await Notifications.getExpoPushTokenAsync({
      projectId: Constants.expoConfig?.extra?.eas?.projectId ?? Constants.easConfig?.projectId,
    });

    console.log('✅ 푸시 토큰:', token);
    const expoPushToken = token.data;
    const encodedToken = expoPushToken.replace(/\[/g, '%5B').replace(/\]/g, '%5D');

    if (Device.isDevice) {
      try {
        const res = await sendPushToken(encodedToken);
        console.log('✅ 푸시 토큰 전송:', res);
      } catch (error) {
        console.error('❌ 푸시 토큰 전송 실패:', JSON.stringify(error));
      }
    }
  };
```
- 콘솔이 정상적으로 뜨면 성공입니다.