### PR TITLE
fix: 탈퇴 요청 시 이미 삭제된 사용자 예외 처리 추가

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -89,13 +89,29 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   const withdraw = async () => {
     try {
-      await Promise.all([deleteAllAlarms(), withdrawApi()]);
+      // 1. 알림 삭제 먼저 시도
+      await deleteAllAlarms();
+
+      // 2. 탈퇴 시도 (실패하더라도 에러를 따로 처리)
+      try {
+        await withdrawApi();
+      } catch (apiError: any) {
+        console.warn('탈퇴 API 에러 발생:', apiError);
+        // USER4041 에러는 무시 (이미 탈퇴된 상태로 간주)
+        if (apiError?.response?.data?.code !== 'USER4041') {
+          throw apiError; // 진짜 에러일 경우만 throw
+        }
+      }
+
+      // 3. 로컬 데이터 정리
       setUser(null);
       await Promise.all([
         SecureStore.deleteItemAsync('accessToken'),
         SecureStore.deleteItemAsync('refreshToken'),
         AsyncStorage.removeItem('user'),
       ]);
+
+      Alert.alert('탈퇴 완료', '정상적으로 탈퇴되었습니다.');
     } catch (error) {
       console.error('회원 탈퇴 중 에러 발생:', error);
       Alert.alert('회원 탈퇴 실패', '다시 시도해 주세요.');


### PR DESCRIPTION
### 변경 내용
- `withdrawApi()` 호출 시 USER4041 응답을 별도 분기 처리
- 이미 탈퇴된 사용자에 대해서는 실패가 아닌 정상 흐름으로 간주
- 이후 토큰 및 상태 정리 로직은 계속 진행되도록 변경

### 이유
- 사용자 탈퇴 요청이 중복 요청되거나, 토큰 만료 등으로 인해 서버에서 USER4041을 반환하는 상황이 있음
- 이 경우 실제 탈퇴는 이미 완료된 상태이므로, UX 상으로 실패 알림을 보여줄 필요 없음

### 테스트
- 탈퇴 요청 호출 시 에러 Alert 없이 정상 처리되는지 확인
- 토큰 삭제 및 상태 초기화 정상 동작 확인
